### PR TITLE
added onload.js to simplify the api 

### DIFF
--- a/physx/source/compiler/cmake/emscripten/PhysXWasmBindings.cmake
+++ b/physx/source/compiler/cmake/emscripten/PhysXWasmBindings.cmake
@@ -16,6 +16,7 @@ SET(PHYSXWASM_GLUE_WRAPPER ${PHYSX_WASM_SOURCE_DIR}/wasm/PhysXWasm.cpp)
 SET(PHYSXWASM_IDL_FILE ${PHYSX_WASM_SOURCE_DIR}/wasm/PhysXWasm.idl)
 SET(EMCC_WASM_ARGS
 		--post-js glue.js
+		--post-js ${PHYSX_WASM_SOURCE_DIR}/wasm/onload.js
 		-s MODULARIZE=1
 		-s EXPORT_NAME=PhysX
 		-s ENVIRONMENT=web,worker

--- a/physx/source/webidlbindings/src/wasm/onload.js
+++ b/physx/source/webidlbindings/src/wasm/onload.js
@@ -1,0 +1,27 @@
+/**
+ * Makes the API a little less verbose
+ */
+Object.defineProperty(PhysX, 'PHYSICS_VERSION', { get() { return PhysX.PxTopLevelFunctions.prototype.PHYSICS_VERSION; }});
+
+//Move PxTopLevelFunctions to PhysX object
+for(const prop in PhysX.PxTopLevelFunctions.prototype) {
+    if(prop !== 'constructor' && !prop.startsWith('get_') && !prop.startsWith('__')) {
+        Object.defineProperty(PhysX, prop, { get() { return PhysX.PxTopLevelFunctions.prototype[prop]; }});
+    }
+}
+
+//Move NativeArrayHelpers to PhysX object
+for(const prop in PhysX.NativeArrayHelpers.prototype) {
+    if(prop !== 'constructor' && !prop.startsWith('get_') && !prop.startsWith('__')) {
+        Object.defineProperty(PhysX, prop, { get() { return PhysX.NativeArrayHelpers.prototype[prop]; }});
+    }
+}
+
+//Group enums
+const regex = /_emscripten_enum_(.*?)_(.*)/;
+const enums = Object.keys(PhysX).filter(key => key.includes('_emscripten_enum_')).map(emscript => emscript.match(regex));
+
+for (const [emscript, enumName, entryName] of enums) {
+    PhysX[enumName] ??= {};
+    Object.defineProperty(PhysX[enumName], entryName, { get() { return PhysX[emscript](); }});
+}


### PR DESCRIPTION

This change should be fully backwards compatible and is only for convenience.

The API was quite verbose and I saw that you had a couple of issues open regarding the enums with emscripten.
To help mitigate this I added an `onload.js` file that will be appended to the Module load process. This lets us clean up the API a bit as described in 

https://github.com/fabmax/physx-js-webidl/issues/5#issuecomment-1021481070

This way you don't have to hand craft the enums, you just have to make sure they follow the same conventions.

I also offloaded the `PxTopLevelFunctions` and `NativeArrayHelpers` prototypes to the main module. 

```js
PhysX.CreateFoundation === PhysX.PxTopLevelFunctions.prototype.CreateFoundation
PhysX.DefaultFilterShader === PhysX.PxTopLevelFunctions.prototype.DefaultFilterShader
PhysX.getU8At === PhysX.NativeArrayHelpers.prototype.getU8At

PhysX.PxIDENTITYEnum.PxIdentity === PhysX_emscripten_enum_PxIDENTITYEnum_PxIdentity()
//etc
```

The `helloworld.html` could then be updated to the following:

```html
<!DOCTYPE html>
<head><title>PhysX Test</title></head>
<body>

    <script src="physx-js-webidl.js"></script>
    <script>
        PhysX().then(function(PhysX) {
            console.log('PhysX loaded');

            var version = PhysX.PHYSICS_VERSION;
            var allocator = new PhysX.PxDefaultAllocator();
            var errorCb = new PhysX.PxDefaultErrorCallback();
            var foundation = PhysX.CreateFoundation(version, allocator, errorCb);
            console.log('Created PxFoundation');

            var tolerances = new PhysX.PxTolerancesScale();
            var physics = PhysX.CreatePhysics(version, foundation, tolerances);
            console.log('Created PxPhysics');
            
            // create scene
            var tmpVec = new PhysX.PxVec3(0, -9.81, 0);
            var sceneDesc = new PhysX.PxSceneDesc(tolerances);
            sceneDesc.set_gravity(tmpVec);
            sceneDesc.set_cpuDispatcher(PhysX.DefaultCpuDispatcherCreate(0));
            sceneDesc.set_filterShader(PhysX.DefaultFilterShader());
            var scene = physics.createScene(sceneDesc);
            console.log('Created scene');
            
            // create a default material
            var material = physics.createMaterial(0.5, 0.5, 0.5);
            // create default simulation shape flags
            var shapeFlags = new PhysX.PxShapeFlags(PhysX.eSCENE_QUERY_SHAPE | PhysX.eSIMULATION_SHAPE);

            // create a few temporary objects used during setup
            var tmpPose = new PhysX.PxTransform(PhysX.PxIDENTITYEnum.PxIdentity);
            var tmpFilterData = new PhysX.PxFilterData(1, 1, 0, 0);

            // create a large static box with size 20x1x20 as ground
            var groundGeometry = new PhysX.PxBoxGeometry(10, 0.5, 10);   // PxBoxGeometry uses half-sizes
            var groundShape = physics.createShape(groundGeometry, material, true, shapeFlags);
            var ground = physics.createRigidStatic(tmpPose);
            groundShape.setSimulationFilterData(tmpFilterData);
            ground.attachShape(groundShape);
            scene.addActor(ground);
            
            // create a small dynamic box with size 1x1x1, which will fall on the ground
            tmpVec.set_x(0); tmpVec.set_y(5); tmpVec.set_z(0);
            tmpPose.set_p(tmpVec);
            var boxGeometry = new PhysX.PxBoxGeometry(0.5, 0.5, 0.5);   // PxBoxGeometry uses half-sizes
            var boxShape = physics.createShape(boxGeometry, material, true, shapeFlags);
            var box = physics.createRigidDynamic(tmpPose);
            boxShape.setSimulationFilterData(tmpFilterData);
            box.attachShape(boxShape);
            scene.addActor(box);

            // clean up temp objects
            PhysX.destroy(groundGeometry);
            PhysX.destroy(boxGeometry);
            PhysX.destroy(tmpFilterData);
            PhysX.destroy(tmpPose);
            PhysX.destroy(tmpVec);
            PhysX.destroy(shapeFlags);
            PhysX.destroy(sceneDesc);
            PhysX.destroy(tolerances);
            console.log('Created scene objects');

            // simulate scene for a bit
            for (var i = 0; i <= 300; i++) {
                scene.simulate(1.0/60.0);
                scene.fetchResults(true);
                if (i % 10 == 0) {
                    var boxHeight = box.getGlobalPose().get_p().get_y();
                    console.log('Sim step ' + i + ': h = ' + boxHeight);
                }
            }

            // cleanup stuff
            scene.removeActor(ground);
            ground.release();
            groundShape.release();

            scene.removeActor(box);
            box.release();
            boxShape.release();

            scene.release();
            material.release();
            physics.release();
            foundation.release();
            PhysX.destroy(errorCb);
            PhysX.destroy(allocator);
            console.log('Cleaned up');
        });
    </script>

</body>
</html>
```