### PR TITLE
added debug render bindings

### DIFF
--- a/physx/source/webidlbindings/src/common/WebIdlBindings.h
+++ b/physx/source/webidlbindings/src/common/WebIdlBindings.h
@@ -99,6 +99,7 @@ typedef physx::vehicle2::PxVehicleSimulationContextType::Enum PxVehicleSimulatio
 typedef physx::vehicle2::PxVehicleSuspensionJounceCalculationType::Enum PxVehicleSuspensionJounceCalculationTypeEnum;
 typedef physx::vehicle2::PxVehicleTireDirectionModes::Enum PxVehicleTireDirectionModesEnum;
 typedef physx::PxVisualizationParameter::Enum PxVisualizationParameterEnum;
+typedef physx::PxDebugColor::Enum PxDebugColorEnum;
 
 // typedefs for vehicle lookup tables
 typedef physx::vehicle2::PxVehicleFixedSizeLookupTable<physx::PxReal,3> PxVehicleFixedSizeLookupTableFloat_3;
@@ -529,6 +530,18 @@ struct NativeArrayHelpers {
     }
 
     static physx::PxVec3* getVec3At(physx::PxVec3* base, int index) {
+        return &base[index];
+    }
+
+    static physx::PxDebugPoint* getDebugPointAt(physx::PxDebugPoint* base, int index) {
+        return &base[index];
+    }
+
+    static physx::PxDebugLine* getDebugLineAt(physx::PxDebugLine* base, int index) {
+        return &base[index];
+    }
+
+    static physx::PxDebugTriangle* getDebugTriangleAt(physx::PxDebugTriangle* base, int index) {
         return &base[index];
     }
 

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -150,6 +150,9 @@ interface NativeArrayHelpers {
     static PxShape getShapeAt(PxShape base, long index);
     static PxTriggerPair getTriggerPairAt(PxTriggerPair base, long index);
     static PxVec3 getVec3At(PxVec3 base, long index);
+    static PxDebugPoint getDebugPointAt(PxDebugPoint base, long index);
+    static PxDebugLine getDebugLineAt(PxDebugLine base, long index);
+    static PxDebugTriangle getDebugTriangleAt(PxDebugTriangle base, long index);
 };
 
 interface PassThroughFilterShader {
@@ -1915,6 +1918,49 @@ interface PxRigidStatic {
 PxRigidStatic implements PxRigidActor;
 
 [Prefix="physx::", NoDelete]
+interface PxDebugPoint {
+    [Value] attribute PxVec3 pos;
+    attribute unsigned long color;
+};
+
+[Prefix="physx::", NoDelete]
+interface PxDebugLine {
+    [Value] attribute PxVec3 pos0;
+    attribute unsigned long color0;
+    [Value] attribute PxVec3 pos1;
+    attribute unsigned long color1;
+};
+
+[Prefix="physx::", NoDelete]
+interface PxDebugTriangle {
+    [Value] attribute PxVec3 pos0;
+    attribute unsigned long color0;
+    [Value] attribute PxVec3 pos1;
+    attribute unsigned long color1;
+    [Value] attribute PxVec3 pos2;
+    attribute unsigned long color2;
+};
+
+[Prefix="physx::", NoDelete]
+interface PxRenderBuffer {
+    unsigned long getNbPoints();
+    [Const] PxDebugPoint getPoints();
+    void addPoint([Const, Ref] PxDebugPoint point);
+    unsigned long getNbLines();
+    [Const] PxDebugLine getLines();
+    void addLine([Const, Ref] PxDebugLine line);
+    PxDebugLine reserveLines([Const] unsigned long nbLines);
+    PxDebugPoint reservePoints([Const] unsigned long nbLines);
+    unsigned long getNbTriangles();
+    [Const] PxDebugTriangle getTriangles();
+    void addTriangle([Const, Ref] PxDebugTriangle triangle);
+    void append([Const, Ref] PxRenderBuffer other);
+    void clear();
+    void shift([Const, Ref] PxVec3 delta);
+    boolean empty();
+};
+
+[Prefix="physx::", NoDelete]
 interface PxScene {
     boolean addActor([Ref] PxActor actor, [Const] optional PxBVHStructure bvhStructure);
     void removeActor([Ref] PxActor actor, optional boolean wakeOnLostTouch);
@@ -2000,6 +2046,7 @@ interface PxScene {
     [Value] PxSceneLimits getLimits();
     [Ref] PxPhysics getPhysics();
     unsigned long getTimestamp();
+    [Const, Ref] PxRenderBuffer getRenderBuffer();
     attribute VoidPtr userData;
 };
 PxScene implements PxSceneSQSystem;
@@ -3920,3 +3967,17 @@ enum PxVisualizationParameterEnum {
     "PxVisualizationParameterEnum::eFORCE_DWORD"
 };
 
+enum PxDebugColorEnum {
+    "PxDebugColorEnum::eARGB_BLACK",
+    "PxDebugColorEnum::eARGB_RED",
+    "PxDebugColorEnum::eARGB_GREEN",
+    "PxDebugColorEnum::eARGB_BLUE",
+    "PxDebugColorEnum::eARGB_YELLOW",
+    "PxDebugColorEnum::eARGB_MAGENTA",
+    "PxDebugColorEnum::eARGB_CYAN",
+    "PxDebugColorEnum::eARGB_WHITE",
+    "PxDebugColorEnum::eARGB_GREY",
+    "PxDebugColorEnum::eARGB_DARKRED",
+    "PxDebugColorEnum::eARGB_DARKGREEN",
+    "PxDebugColorEnum::eARGB_DARKBLUE"
+};


### PR DESCRIPTION
I wanted a way to visual the scene directly on the web page so I added a few bindings.
Here is an example of a modified `helloworld.html` that shows how to use it:

```html
<!DOCTYPE html>
<head>
    <title>PhysX Test</title>
    <style>
        html, body, canvas {
            margin: 0;
            padding: 0;
            width: 100%;
            height: 100%;
        }
    
        canvas {
            display: block;
        }
    </style>
</head>
<body>
    <canvas></canvas>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/3.4.2/gl-matrix-min.js" integrity="sha512-eV9ExyTa3b+YHr99IBTYpwk4wbgDMDlfW8uTxhywO8dWb810fGUSKDgHhEv1fAqmJT4jyYnt1iWWMW4FRxeQOQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
    <script src="physx-js-webidl.js"></script>
    <script>
        const { mat4, vec4, quat } = glMatrix;

        PhysX().then(function(PhysX) {
            console.log('PhysX loaded');

            var version = PhysX.PxTopLevelFunctions.prototype.PHYSICS_VERSION;
            var allocator = new PhysX.PxDefaultAllocator();
            var errorCb = new PhysX.PxDefaultErrorCallback();
            var foundation = PhysX.PxTopLevelFunctions.prototype.CreateFoundation(version, allocator, errorCb);
            console.log('Created PxFoundation');

            var tolerances = new PhysX.PxTolerancesScale();
            var physics = PhysX.PxTopLevelFunctions.prototype.CreatePhysics(version, foundation, tolerances);
            console.log('Created PxPhysics');
            
            // create scene
            var tmpVec = new PhysX.PxVec3(0, -9.81, 0);
            var sceneDesc = new PhysX.PxSceneDesc(tolerances);
            sceneDesc.set_gravity(tmpVec);
            sceneDesc.set_cpuDispatcher(PhysX.PxTopLevelFunctions.prototype.DefaultCpuDispatcherCreate(0));
            sceneDesc.set_filterShader(PhysX.PxTopLevelFunctions.prototype.DefaultFilterShader());
            var scene = physics.createScene(sceneDesc);
            console.log('Created scene');
            
            // create a default material
            var material = physics.createMaterial(0.5, 0.5, 0.5);
            // create default simulation shape flags
            var shapeFlags = new PhysX.PxShapeFlags(PhysX._emscripten_enum_PxShapeFlagEnum_eSCENE_QUERY_SHAPE() | PhysX._emscripten_enum_PxShapeFlagEnum_eSIMULATION_SHAPE() |  PhysX._emscripten_enum_PxShapeFlagEnum_eVISUALIZATION());

            // create a few temporary objects used during setup
            var tmpPose = new PhysX.PxTransform(PhysX._emscripten_enum_PxIDENTITYEnum_PxIdentity());
            var tmpFilterData = new PhysX.PxFilterData(1, 1, 0, 0);

            // create a large static box with size 20x1x20 as ground
            var groundGeometry = new PhysX.PxBoxGeometry(10, 0.5, 10);   // PxBoxGeometry uses half-sizes
            var groundShape = physics.createShape(groundGeometry, material, true, shapeFlags);
            var ground = physics.createRigidStatic(tmpPose);
            groundShape.setSimulationFilterData(tmpFilterData);
            ground.attachShape(groundShape);
            scene.addActor(ground);
            
            // create a small dynamic box with size 1x1x1, which will fall on the ground
            tmpVec.set_x(0); tmpVec.set_y(5); tmpVec.set_z(0);
            tmpPose.set_p(tmpVec);
            var boxGeometry = new PhysX.PxBoxGeometry(0.5, 0.5, 0.5);   // PxBoxGeometry uses half-sizes
            var boxShape = physics.createShape(boxGeometry, material, true, shapeFlags);
            var box = physics.createRigidDynamic(tmpPose);
            boxShape.setSimulationFilterData(tmpFilterData);
            box.attachShape(boxShape);
            scene.addActor(box);

            // clean up temp objects
            PhysX.destroy(groundGeometry);
            PhysX.destroy(boxGeometry);
            PhysX.destroy(tmpFilterData);
            PhysX.destroy(tmpPose);
            PhysX.destroy(tmpVec);
            PhysX.destroy(shapeFlags);
            PhysX.destroy(sceneDesc);
            PhysX.destroy(tolerances);
            console.log('Created scene objects');

            //Setup simple view projection
            const canvas  = document.querySelector('canvas');
            canvas.width  = canvas.clientWidth;
            canvas.height = canvas.clientHeight;
            
            const viewMatrix           = mat4.invert(mat4.create(), mat4.fromRotationTranslation(mat4.create(), quat.fromEuler(quat.create(), -40, 40, 0), [20, 20, 20]));
            const projectionMatrix     = mat4.perspective(mat4.create(), 45 * (Math.PI / 180), canvas.width / canvas.height, 0.01, 75);
            const viewProjectionMatrix = mat4.multiply(mat4.create(), projectionMatrix, viewMatrix);
            
            const tmpVec4 = vec4.create();
            function project(x, y, z) {
                const result = vec4.transformMat4(tmpVec4, [x, y, z, 1], viewProjectionMatrix);
                const clipX = (result[0] / result[3]);
                const clipY = (result[1] / result[3]);
                return [(canvas.width / 2) * (1 + clipX), (canvas.height / 2) * (1 - clipY)];
            }

            //Setup debug drawer
            const context = canvas.getContext('2d');
            const colors = {
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_BLACK()]:     [  0,   0,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_RED()]:       [  1,   0,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_GREEN()]:     [  0,   1,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_BLUE()]:      [  0,   0,   1],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_YELLOW()]:    [  1,   1,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_MAGENTA()]:   [  1,   0,   1],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_CYAN()]:      [  0,   1,   1],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_WHITE()]:     [  1,   1,   1],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_GREY()]:      [0.5, 0.5, 0.5],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_DARKRED()]:   [0.5,   0,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_DARKGREEN()]: [  0, 0.5,   0],
                [PhysX._emscripten_enum_PxDebugColorEnum_eARGB_DARKBLUE()]:  [  0,   0, 0.5],
            };
            scene.setVisualizationParameter(PhysX.eSCALE, 1);
            scene.setVisualizationParameter(PhysX.eWORLD_AXES, 1);
            scene.setVisualizationParameter(PhysX.eACTOR_AXES, 1);
            scene.setVisualizationParameter(PhysX.eCOLLISION_SHAPES, 1);

            function drawLine(from, to, color) {
                const [r, g, b] = color;

                context.beginPath();
                context.strokeStyle = `rgb(${255 * r}, ${255 * g}, ${255 * b})`;
                context.moveTo(...from);
                context.lineTo(...to);
                context.stroke();
            }

            function debugDraw() {
                const rb = scene.getRenderBuffer();

                for(let i = 0; i < rb.getNbLines(); i++) {
                    const line = PhysX.NativeArrayHelpers.prototype.getDebugLineAt(rb.getLines(), i);
                    const from = project(line.pos0.get_x(), line.pos0.get_y(), line.pos0.get_z());
                    const to   = project(line.pos1.get_x(), line.pos1.get_y(), line.pos1.get_z());
                    drawLine(from, to, colors[line.get_color0()]);
                }
            }

            // simulate in loop
            let lastFrame = 0;
            requestAnimationFrame(function loop(hrTime){    
                canvas.width = canvas.width;//clear canvas            
                scene.simulate((hrTime - lastFrame) / 1000);
                scene.fetchResults(true);
                debugDraw();

                lastFrame = hrTime;
                requestAnimationFrame(loop);
            });
        });
    </script>

</body>
</html>
```

The output looks like this:

![debug-render](https://user-images.githubusercontent.com/1154610/206093914-e9d1c6ab-26ca-4bda-b730-653fae74c789.gif)

