### PR TITLE
add PxQueryHitType enums

### DIFF
--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -4105,6 +4105,12 @@ enum PxHitFlagEnum {
     "PxHitFlagEnum::eMODIFIABLE_FLAGS"
 };
 
+enum PxQueryHitType {
+    "PxQueryHitType::eNONE",
+    "PxQueryHitType::eBLOCK",
+    "PxQueryHitType::eTOUCH"
+};
+
 enum PxIDENTITYEnum {
     "PxIDENTITYEnum::PxIdentity"
 };


### PR DESCRIPTION
Added the PxQueryHitType enums so that they can be used in a PxQueryFilterCallback (eg for custom character controller collision)