### PR TITLE
Add SimpleFactory functions

### DIFF
--- a/physx/source/webidlbindings/src/common/WebIdlBindings.h
+++ b/physx/source/webidlbindings/src/common/WebIdlBindings.h
@@ -337,6 +337,50 @@ struct PxTopLevelFunctions {
     static physx::PxHeightField* CreateHeightField(const physx::PxHeightFieldDesc &desc) {
         return PxCreateHeightField(desc);
     }
+
+    static physx::PxRigidDynamic* CreateDynamicFromShape(physx::PxPhysics& sdk, const physx::PxTransform& transform, physx::PxShape& shape, physx::PxReal density) {
+        return PxCreateDynamic(sdk, transform, shape, density);
+    }
+
+    static physx::PxRigidDynamic* CreateDynamic(physx::PxPhysics& sdk, const physx::PxTransform& transform, const physx::PxGeometry& geometry, physx::PxMaterial& material, physx::PxReal density, const physx::PxTransform& shapeOffset = physx::PxTransform(physx::PxIdentity)) {
+        return PxCreateDynamic(sdk, transform, geometry, material, density, shapeOffset);
+    }
+
+    static physx::PxRigidDynamic* CreateKinematicFromShape(physx::PxPhysics& sdk, const physx::PxTransform& transform, physx::PxShape& shape, physx::PxReal density) {
+        return PxCreateKinematic(sdk, transform, shape, density);
+    }
+
+    static physx::PxRigidDynamic* CreateKinematic(physx::PxPhysics& sdk, const physx::PxTransform& transform, const physx::PxGeometry& geometry, physx::PxMaterial& material, physx::PxReal density, const physx::PxTransform& shapeOffset = physx::PxTransform(physx::PxIdentity)) {
+        return PxCreateKinematic(sdk, transform, geometry, material, density, shapeOffset);
+    }
+
+    static physx::PxRigidStatic* CreateStaticFromShape(physx::PxPhysics& sdk, const physx::PxTransform& transform, physx::PxShape& shape) {
+        return PxCreateStatic(sdk, transform, shape);
+    }
+
+    static physx::PxRigidStatic* CreateStatic(physx::PxPhysics& sdk, const physx::PxTransform& transform, const physx::PxGeometry& geometry, physx::PxMaterial& material, const physx::PxTransform& shapeOffset) {
+        return PxCreateStatic(sdk, transform, geometry, material, shapeOffset);
+    }
+
+    static physx::PxRigidStatic* CreatePlane(physx::PxPhysics& sdk, const physx::PxPlane& plane, physx::PxMaterial& material) {
+        return PxCreatePlane(sdk, plane, material);
+    }
+
+    static physx::PxShape* CloneShape(physx::PxPhysics& physics, const physx::PxShape& from, bool isExclusive) {
+        return PxCloneShape(physics, from, isExclusive);
+    }
+
+    static physx::PxRigidStatic* CloneStatic(physx::PxPhysics& physicsSDK, const physx::PxTransform& transform, const physx::PxRigidActor& from) {
+        return PxCloneStatic(physicsSDK, transform, from);
+    }
+
+    static physx::PxRigidDynamic* CloneDynamic(physx::PxPhysics& physicsSDK, const physx::PxTransform& transform, const physx::PxRigidDynamic& from) {
+        return PxCloneDynamic(physicsSDK, transform, from);
+    }
+
+    static void ScaleRigidActor(physx::PxRigidActor& actor, physx::PxReal scale, bool scaleMassProps) {
+        return PxScaleRigidActor(actor, scale, scaleMassProps);
+    }
 };
 
 struct PxVehicleTopLevelFunctions {

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -2717,6 +2717,23 @@ interface PxTopLevelFunctions {
     static PxTriangleMesh CreateTriangleMesh([Const, Ref] PxCookingParams params, [Const, Ref] PxTriangleMeshDesc desc);
     static PxHeightField CreateHeightField([Const, Ref] PxHeightFieldDesc desc);
     static readonly attribute unsigned long PHYSICS_VERSION;
+
+    static PxRigidDynamic CreateDynamicFromShape([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Ref] PxShape shape, float density);
+    static PxRigidDynamic CreateDynamic([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Const, Ref] PxGeometry geometry, [Ref] PxMaterial material, float density, [Const, Ref] optional PxTransform shapeOffset);
+
+    static PxRigidDynamic CreateKinematicFromShape([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Ref] PxShape shape, float density);
+    static PxRigidDynamic CreateKinematic([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Const, Ref] PxGeometry geometry, [Ref] PxMaterial material, float density, [Const, Ref] optional PxTransform shapeOffset);
+
+    static PxRigidStatic CreateStaticFromShape([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Ref] PxShape shape);
+    static PxRigidStatic CreateStatic([Ref] PxPhysics sdk, [Const, Ref] PxTransform transform, [Const, Ref] PxGeometry geometry, [Ref] PxMaterial material, [Const, Ref] PxTransform shapeOffset);
+
+    static PxRigidStatic CreatePlane([Ref] PxPhysics sdk, [Const, Ref] PxPlane plane, [Ref] PxMaterial material);
+
+    static PxShape CloneShape([Ref] PxPhysics physics, [Const, Ref] PxShape from, boolean isExclusive);
+    static PxRigidStatic CloneStatic([Ref] PxPhysics physicsSDK, [Const, Ref] PxTransform transform, [Const, Ref] PxRigidActor from);
+    static PxRigidDynamic CloneDynamic([Ref] PxPhysics physicsSDK, [Const, Ref] PxTransform transform, [Const, Ref] PxRigidDynamic from);
+
+    static void ScaleRigidActor([Ref] PxRigidActor actor, float scale, boolean scaleMassProps);
 };
 
 [Prefix="physx::"]


### PR DESCRIPTION
Adding SimpleFactory functions from:
- [`PxSimpleFactory.h`](https://github.com/fabmax/PhysX/blob/webidl-bindings/physx/include/extensions/PxSimpleFactory.h)
- [`ExtSimpleFactory.cpp`](https://github.com/fabmax/PhysX/blob/webidl-bindings/physx/source/physxextensions/src/ExtSimpleFactory.cpp)

Please see the mention of `PxSimpleFactory.h` in [PhysX 5.4.1 `RigidBody` Documentation](https://nvidia-omniverse.github.io/PhysX/physx/5.4.1/docs/RigidBodyOverview.html)
