### PR TITLE
Expose `IntegrateTransform()`

### DIFF
--- a/physx/source/webidlbindings/src/common/WebIdlBindings.h
+++ b/physx/source/webidlbindings/src/common/WebIdlBindings.h
@@ -381,6 +381,10 @@ struct PxTopLevelFunctions {
     static void ScaleRigidActor(physx::PxRigidActor& actor, physx::PxReal scale, bool scaleMassProps) {
         return PxScaleRigidActor(actor, scale, scaleMassProps);
     }
+
+    static void IntegrateTransform(const physx::PxTransform& curTrans, const physx::PxVec3& linvel, const physx::PxVec3& angvel, physx::PxReal timeStep, physx::PxTransform& result) {
+        return PxIntegrateTransform(curTrans, linvel, angvel, timeStep, result);
+    }
 };
 
 struct PxVehicleTopLevelFunctions {

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -2734,6 +2734,8 @@ interface PxTopLevelFunctions {
     static PxRigidDynamic CloneDynamic([Ref] PxPhysics physicsSDK, [Const, Ref] PxTransform transform, [Const, Ref] PxRigidDynamic from);
 
     static void ScaleRigidActor([Ref] PxRigidActor actor, float scale, boolean scaleMassProps);
+
+    static void IntegrateTransform([Const, Ref] PxTransform curTrans, [Const, Ref] PxVec3 linvel, [Const, Ref] PxVec3 angvel, float timeStep, [Ref] PxTransform result);
 };
 
 [Prefix="physx::"]


### PR DESCRIPTION
`setLinearVelocity()` and `setAngularVelocity()` [cannot be used for Kinematic bodies](https://github.com/NVIDIA-Omniverse/PhysX/blob/main/physx/source/physx/src/NpRigidDynamic.cpp#L232). Instead, `setKinematicTarget()` must be used for Kinematic bodies.

PhysX has a useful function [`PxIntegrateTransform()`](https://github.com/NVIDIA-Omniverse/PhysX/blob/main/physx/source/foundation/FdMathUtils.cpp#L177) that predicts the transform of a body after a timestep given an input linear and angular velocity. The predicted transform can then be input into `setKinematicTarget()`. This unlocks  a way to control Kinematic bodies by specifying a linear and angular velocity.
