### PR TITLE
add support for web worker cooking + efficient vectors from a buffer

### DIFF
--- a/physx/source/webidlbindings/src/common/PxTypeMappings.h
+++ b/physx/source/webidlbindings/src/common/PxTypeMappings.h
@@ -2,6 +2,7 @@
 #define PX_TYPE_MAPPINGS_H
 
 #include "PxPhysicsAPI.h"
+#include <cstring> // for memcpy
 
 // typedefs for vehicle lookup tables
 typedef physx::vehicle2::PxVehicleFixedSizeLookupTable<physx::PxReal,3> PxVehicleFixedSizeLookupTableFloat_3;
@@ -52,6 +53,11 @@ public:
     PX_INLINE T& at(uint32_t index) { return this->operator[](index); }
     PX_INLINE void push_back(const T& value) { this->pushBack(value); }
     PX_INLINE T* data() { return this->begin(); }
+    PX_INLINE void setFromBuffer(const void* buffer, uint32_t size) {
+        this->reset();
+        this->resize(size);
+        std::memcpy(this->begin(), buffer, size * sizeof(T));
+    }
 };
 
 class PxArray_PxVec3 : public PxArrayExt<physx::PxVec3> {

--- a/physx/source/webidlbindings/src/common/WebIdlBindings.h
+++ b/physx/source/webidlbindings/src/common/WebIdlBindings.h
@@ -337,6 +337,14 @@ struct PxTopLevelFunctions {
     static physx::PxHeightField* CreateHeightField(const physx::PxHeightFieldDesc &desc) {
         return PxCreateHeightField(desc);
     }
+
+    static bool CookTriangleMesh(const physx::PxCookingParams& params, const physx::PxTriangleMeshDesc& desc, physx::PxOutputStream& stream) {
+        return PxCookTriangleMesh(params, desc, stream);
+    }
+
+    static bool CookConvexMesh(const physx::PxCookingParams& params, const physx::PxConvexMeshDesc& desc, physx::PxOutputStream& stream) {
+        return PxCookConvexMesh(params, desc, stream);
+    }
 };
 
 struct PxVehicleTopLevelFunctions {

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -427,6 +427,7 @@ interface PxArray_PxU8 {
     VoidPtr begin();
     unsigned long size();
     void pushBack(octet value);
+    void setFromBuffer(VoidPtr buffer, unsigned long size);
     void clear();
 };
 
@@ -3772,7 +3773,6 @@ interface Vector_PxU8 {
     unsigned long size();
     void push_back(octet value);
     void clear();
-    void setFromBuffer(VoidPtr buffer, unsigned long size);
 };
 
 interface Vector_PxVec3 {

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -1870,6 +1870,8 @@ interface PxPhysics {
     PxRigidStatic createRigidStatic([Const, Ref] PxTransform pose);
     PxRigidDynamic createRigidDynamic([Const, Ref] PxTransform pose);
     PxShape createShape([Const, Ref] PxGeometry geometry, [Const, Ref] PxMaterial material, optional boolean isExclusive, [Ref] optional PxShapeFlags shapeFlags);
+    PxTriangleMesh createTriangleMesh([Ref] PxInputData stream);
+    PxConvexMesh createConvexMesh([Ref] PxInputData stream);
     long getNbShapes();
     PxArticulationReducedCoordinate createArticulationReducedCoordinate();
     PxMaterial createMaterial(float staticFriction, float dynamicFriction, float restitution);
@@ -2713,6 +2715,8 @@ interface PxTopLevelFunctions {
     static PxConvexMesh CreateConvexMesh([Const, Ref] PxCookingParams params, [Const, Ref] PxConvexMeshDesc desc);
     static PxTriangleMesh CreateTriangleMesh([Const, Ref] PxCookingParams params, [Const, Ref] PxTriangleMeshDesc desc);
     static PxHeightField CreateHeightField([Const, Ref] PxHeightFieldDesc desc);
+    static boolean CookTriangleMesh([Const, Ref] PxCookingParams params, [Const, Ref] PxTriangleMeshDesc desc, [Ref] PxOutputStream stream);
+    static boolean CookConvexMesh([Const, Ref] PxCookingParams params, [Const, Ref] PxConvexMeshDesc desc, [Ref] PxOutputStream stream);
     static readonly attribute unsigned long PHYSICS_VERSION;
 };
 
@@ -3768,6 +3772,7 @@ interface Vector_PxU8 {
     unsigned long size();
     void push_back(octet value);
     void clear();
+    void setFromBuffer(VoidPtr buffer, unsigned long size);
 };
 
 interface Vector_PxVec3 {


### PR DESCRIPTION
This PR supports efficiently cooking from a web worker, eg like this:

```jsx
// in a web worker cook a triangle mesh into a Uint8Array data format
const desc = new PHYSX.PxTriangleMeshDesc()
desc.points.count = points.size()
desc.points.stride = 12 
desc.points.data = points.data()
desc.triangles.count = triangles.size() / 3
desc.triangles.stride = 12 
desc.triangles.data = triangles.data()
const buf = new PHYSX.PxDefaultMemoryOutputStream()
PHYSX.CookTriangleMesh(cookingParams, desc, buf)
const size = buf.getSize()
const dataPtr = PHYSX.NativeArrayHelpers.prototype.voidToU8Ptr(buf.getData())
const data = new Uint8Array(PHYSX.HEAPU8.buffer, dataPtr, size)

// transfer back to main thread
self.postMessage({ data }, [data])

// back on main thread reconstruct into PxTriangleMesh
const buf = PHYSX._malloc(data.length)
PHYSX.HEAPU8.set(data, buf)
const pxu8 = new PHYSX.Vector_PxU8()
pxu8.setFromBuffer(buf, data.length)
PHYSX._webidl_free(buf)
const inputStream = new PHYSX.PxDefaultMemoryInputData(pxu8, pxu8.size())
const pxTriangleMesh = physics.createTriangleMesh(inputStream)
```

In my case larger triangle meshes were taking ~30ms to generate, but by moving this to a worker the main thread now only spends ~0.1ms