### PR TITLE
Reuse Scene Query result callbacks

### DIFF
--- a/physx/source/webidlbindings/src/common/WebIdlBindings.h
+++ b/physx/source/webidlbindings/src/common/WebIdlBindings.h
@@ -223,6 +223,10 @@ class PxHitResult : public physx::PxHitCallback<HitType> {
             return hits[index];
         }
 
+        PX_INLINE void clear() {
+            hits.clear();
+        }
+
     protected:
         virtual physx::PxAgain processTouches(const HitType* buffer, physx::PxU32 nbHits) {
             if (isFinalized) {

--- a/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
+++ b/physx/source/webidlbindings/src/wasm/PhysXWasm.idl
@@ -1870,6 +1870,7 @@ interface PxOverlapResult {
     [Const, Ref] PxOverlapHit getAnyHit(unsigned long index);
     unsigned long getNbTouches();
     [Const, Ref] PxOverlapHit getTouch(unsigned long index);
+    void clear();
     [Value] attribute PxOverlapHit block;
     attribute boolean hasBlock;
 };
@@ -2086,6 +2087,7 @@ interface PxRaycastResult {
     [Const, Ref] PxRaycastHit getAnyHit(unsigned long index);
     unsigned long getNbTouches();
     [Const, Ref] PxRaycastHit getTouch(unsigned long index);
+    void clear();
     [Value] attribute PxRaycastHit block;
     attribute boolean hasBlock;
 };
@@ -2664,6 +2666,7 @@ interface PxSweepResult {
     [Const, Ref] PxSweepHit getAnyHit(unsigned long index);
     unsigned long getNbTouches();
     [Const, Ref] PxSweepHit getTouch(unsigned long index);
+    void clear();
     [Value] attribute PxSweepHit block;
     attribute boolean hasBlock;
 };


### PR DESCRIPTION
Currently, we have to create a new `PxRaycastResult` every time we call `PxSceneQuerySystemBase.raycast()`. If a raycast collects a hit, that hit cannot be cleared, and `PxRaycastResult` cannot be reset to be used for another `raycast()` call. The same applies sweeps and overlaps.

This PR exposes a `clear()` function that should allow users to reuse these result callbacks. Hopefully, creating less new objects can lead to better performance.

