### PR TITLE
Suppress `-Wunique-object-duplication` in emscripten Clang warnings after emsdk (4.0.19) upgrade

### DIFF
--- a/physx/source/compiler/cmake/emscripten/CMakeLists.txt
+++ b/physx/source/compiler/cmake/emscripten/CMakeLists.txt
@@ -93,6 +93,7 @@ SET(CLANG_WARNINGS "-ferror-limit=0 -Wall -Wextra -Werror -Wstrict-aliasing=2 -W
     -Wno-missing-include-dirs \
     -Wno-nrvo \
     -Wno-format-signedness \
+    -Wno-unique-object-duplication \
 ")
 
 # Set to true to enable multi-threading - works but is difficult to use


### PR DESCRIPTION
Clang bundled with newer emsdk (4.0.19) introduces `-Wunique-object-duplication`, which flags the `static PxU32 timestamp` inside the `PX_WARN_ONCE` macro as potentially duplicated across shared-library boundaries due to `-fvisibility=hidden` combined with external linkage.

Without `-Wunique-object-duplication`, you get several build errors from `./make.sh` like:

```shell
In file included from /src/PhysX/physx/source/lowlevel/common/src/pipeline/PxcContactCache.cpp:32:
/src/PhysX/physx/source/lowlevel/common/include/pipeline/PxcNpCache.h:55:3: error: 'timestamp' may be duplicated when built into a shared library: it is mutable, with
      external linkage and hidden visibility [-Werror,-Wunique-object-duplication]
   55 |                 PX_WARN_ONCE(
      |                 ^
/src/PhysX/physx/include/foundation/PxErrors.h:103:17: note: expanded from macro 'PX_WARN_ONCE'
  103 |                         static PxU32 timestamp = 0;                                             \
      |                                      ^
In file included from /src/PhysX/physx/source/lowlevel/common/src/pipeline/PxcContactCache.cpp:32:
/src/PhysX/physx/source/lowlevel/common/include/pipeline/PxcNpCache.h:61:3: error: 'timestamp' may be duplicated when built into a shared library: it is mutable, with
      external linkage and hidden visibility [-Werror,-Wunique-object-duplication]
   61 |                 PX_WARN_ONCE(
      |                 ^
/src/PhysX/physx/include/foundation/PxErrors.h:103:17: note: expanded from macro 'PX_WARN_ONCE'
  103 |                         static PxU32 timestamp = 0;                                             \
      |                                      ^
2 errors generated.
make[2]: *** [sdk_source_bin/CMakeFiles/LowLevel.dir/build.make:92: sdk_source_bin/CMakeFiles/LowLevel.dir/src/PhysX/physx/source/lowlevel/common/src/pipeline/PxcContactCache.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:154: sdk_source_bin/CMakeFiles/LowLevel.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

Thank you, @fabmax !
